### PR TITLE
Use int32 internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+v1.1.0
+
+## BREAKING CHANGES
+
+* Switched to using int32 internally to keep on par with the original version,
+while the interface remains the same the noise values differ from `v1.0.0`
+
+v1.0.0
+
+* Initial version

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-## GO Perlin Noise generator [![Go Reference](https://pkg.go.dev/badge/github.com/aquilax/go-perlin.svg)](https://pkg.go.dev/github.com/aquilax/go-perlin)
+# GO Perlin Noise generator [![Go Reference](https://pkg.go.dev/badge/github.com/aquilax/go-perlin.svg)](https://pkg.go.dev/github.com/aquilax/go-perlin)
 
-Adapted for go from GEGL http://git.gnome.org/browse/gegl/tree/operations/common/perlin
+Adapted for go from [GEGL](http://git.gnome.org/browse/gegl/tree/operations/common/perlin)
 
-
-Example: perlin.Noise1D
+Example: `perlin.Noise1D`
 
     alpha = 2
     beta = 2
@@ -11,6 +10,6 @@ Example: perlin.Noise1D
 
 ![PerlinNoise1D](http://i.imgur.com/Kplg5.png)
 
-Using perlin.Noise2D with termbox to generate terrain in terminal:
+Using `perlin.Noise2D` with termbox to generate terrain in terminal:
 
 ![PerlinNoise2D](http://i.imgur.com/vPi3n.png)

--- a/example_test.go
+++ b/example_test.go
@@ -17,37 +17,37 @@ const (
 func ExampleNewPerlinRandSource() {
 	p := perlin.NewPerlinRandSource(alpha, beta, n, rand.NewSource(seed))
 	for x := 0.; x < 3; x++ {
-		fmt.Printf("%0.0f\t%0.4f\n", x, p.Noise1D(x/10))
+		fmt.Printf("%0.0f;%0.4f\n", x, p.Noise1D(x/10))
 	}
 	// Output:
-	// 0	0.0000
-	// 1	-0.1670
-	// 2	-0.2011
+	// 0;0.0000
+	// 1;-0.0086
+	// 2;-0.0017
 }
 
 func ExamplePerlin_Noise1D() {
 	p := perlin.NewPerlin(alpha, beta, n, seed)
 	for x := 0.; x < 3; x++ {
-		fmt.Printf("%0.0f\t%0.4f\n", x, p.Noise1D(x/10))
+		fmt.Printf("%0.0f;%0.4f\n", x, p.Noise1D(x/10))
 	}
 	// Output:
-	// 0	0.0000
-	// 1	-0.1670
-	// 2	-0.2011
+	// 0;0.0000
+	// 1;-0.0086
+	// 2;-0.0017
 }
 
 func ExamplePerlin_Noise2D() {
 	p := perlin.NewPerlin(alpha, beta, n, seed)
 	for x := 0.; x < 2; x++ {
 		for y := 0.; y < 2; y++ {
-			fmt.Printf("%0.0f\t%0.0f\t%0.4f\n", x, y, p.Noise2D(x/10, y/10))
+			fmt.Printf("%0.0f;%0.0f;%0.4f\n", x, y, p.Noise2D(x/10, y/10))
 		}
 	}
 	// Output:
-	// 0	0	0.0000
-	// 0	1	-0.0060
-	// 1	0	0.1230
-	// 1	1	0.0625
+	// 0;0;0.0000
+	// 0;1;-0.2002
+	// 1;0;-0.3389
+	// 1;1;-0.5045
 }
 
 func ExamplePerlin_Noise3D() {
@@ -55,17 +55,17 @@ func ExamplePerlin_Noise3D() {
 	for x := 0.; x < 2; x++ {
 		for y := 0.; y < 2; y++ {
 			for z := 0.; z < 2; z++ {
-				fmt.Printf("%0.0f\t%0.0f\t%0.0f\t%0.4f\n", x, y, z, p.Noise3D(x/10, y/10, z/10))
+				fmt.Printf("%0.0f;%0.0f;%0.0f;%0.4f\n", x, y, z, p.Noise3D(x/10, y/10, z/10))
 			}
 		}
 	}
 	// Output:
-	// 0	0	0	0.0000
-	// 0	0	1	0.1881
-	// 0	1	0	0.1384
-	// 0	1	1	0.2507
-	// 1	0	0	-0.0416
-	// 1	0	1	0.1232
-	// 1	1	0	0.0536
-	// 1	1	1	0.1826
+	// 0;0;0;0.0000
+	// 0;0;1;0.2616
+	// 0;1;0;-0.0755
+	// 0;1;1;0.2020
+	// 1;0;0;-0.2138
+	// 1;0;1;0.0616
+	// 1;1;0;-0.2208
+	// 1;1;1;0.0304
 }

--- a/perlin.go
+++ b/perlin.go
@@ -20,9 +20,9 @@ const (
 type Perlin struct {
 	alpha float64
 	beta  float64
-	n     int
+	n     int32
 
-	p  [B + B + 2]int
+	p  [B + B + 2]int32
 	g3 [B + B + 2][3]float64
 	g2 [B + B + 2][2]float64
 	g1 [B + B + 2]float64
@@ -33,7 +33,7 @@ type Perlin struct {
 // Typically it is 2, As this approaches 1 the function is noisier.
 // "beta" is the harmonic scaling/spacing, typically 2, n is the
 // number of iterations and seed is the math.rand seed value to use
-func NewPerlin(alpha, beta float64, n int, seed int64) *Perlin {
+func NewPerlin(alpha, beta float64, n int32, seed int64) *Perlin {
 	return NewPerlinRandSource(alpha, beta, n, rand.NewSource(seed))
 }
 
@@ -42,9 +42,9 @@ func NewPerlin(alpha, beta float64, n int, seed int64) *Perlin {
 // Typically it is 2, As this approaches 1 the function is noisier.
 // "beta" is the harmonic scaling/spacing, typically 2, n is the
 // number of iterations and source is source of pseudo-random int64 values
-func NewPerlinRandSource(alpha, beta float64, n int, source rand.Source) *Perlin {
+func NewPerlinRandSource(alpha, beta float64, n int32, source rand.Source) *Perlin {
 	var p Perlin
-	var i, j, k int
+	var i, j, k int32
 
 	p.alpha = alpha
 	p.beta = beta
@@ -54,23 +54,23 @@ func NewPerlinRandSource(alpha, beta float64, n int, source rand.Source) *Perlin
 
 	for i = 0; i < B; i++ {
 		p.p[i] = i
-		p.g1[i] = float64((r.Int()%(B+B))-B) / B
+		p.g1[i] = float64((r.Int31()%(B+B))-B) / B
 
 		for j = 0; j < 2; j++ {
-			p.g2[i][j] = float64((r.Int()%(B+B))-B) / B
+			p.g2[i][j] = float64((r.Int31()%(B+B))-B) / B
 		}
 
 		normalize2(&p.g2[i])
 
 		for j = 0; j < 3; j++ {
-			p.g3[i][j] = float64((r.Int()%(B+B))-B) / B
+			p.g3[i][j] = float64((r.Int31()%(B+B))-B) / B
 		}
 		normalize3(&p.g3[i])
 	}
 
 	for ; i > 0; i-- {
 		k = p.p[i]
-		j = r.Int() % B
+		j = r.Int31() % B
 		p.p[i] = p.p[j]
 		p.p[j] = k
 	}
@@ -123,9 +123,9 @@ func (p *Perlin) noise1(arg float64) float64 {
 	vec[0] = arg
 
 	t := vec[0] + N
-	bx0 := int(t) & BM
+	bx0 := int32(t) & BM
 	bx1 := (bx0 + 1) & BM
-	rx0 := t - float64(int(t))
+	rx0 := t - float64(int32(t))
 	rx1 := rx0 - 1.
 
 	sx := sCurve(rx0)
@@ -137,15 +137,15 @@ func (p *Perlin) noise1(arg float64) float64 {
 
 func (p *Perlin) noise2(vec [2]float64) float64 {
 	t := vec[0] + N
-	bx0 := int(t) & BM
+	bx0 := int32(t) & BM
 	bx1 := (bx0 + 1) & BM
-	rx0 := t - float64(int(t))
+	rx0 := t - float64(int32(t))
 	rx1 := rx0 - 1.
 
 	t = vec[1] + N
-	by0 := int(t) & BM
+	by0 := int32(t) & BM
 	by1 := (by0 + 1) & BM
-	ry0 := t - float64(int(t))
+	ry0 := t - float64(int32(t))
 	ry1 := ry0 - 1.
 
 	i := p.p[bx0]
@@ -176,21 +176,21 @@ func (p *Perlin) noise2(vec [2]float64) float64 {
 
 func (p *Perlin) noise3(vec [3]float64) float64 {
 	t := vec[0] + N
-	bx0 := int(t) & BM
+	bx0 := int32(t) & BM
 	bx1 := (bx0 + 1) & BM
-	rx0 := t - float64(int(t))
+	rx0 := t - float64(int32(t))
 	rx1 := rx0 - 1.
 
 	t = vec[1] + N
-	by0 := int(t) & BM
+	by0 := int32(t) & BM
 	by1 := (by0 + 1) & BM
-	ry0 := t - float64(int(t))
+	ry0 := t - float64(int32(t))
 	ry1 := ry0 - 1.
 
 	t = vec[2] + N
-	bz0 := int(t) & BM
+	bz0 := int32(t) & BM
 	bz1 := (bz0 + 1) & BM
-	rz0 := t - float64(int(t))
+	rz0 := t - float64(int32(t))
 	rz1 := rz0 - 1.
 
 	i := p.p[bx0]
@@ -240,10 +240,10 @@ func (p *Perlin) noise3(vec [3]float64) float64 {
 func (p *Perlin) Noise1D(x float64) float64 {
 	var scale float64 = 1
 	var sum, val float64
-
+	var i int32
 	px := x
 
-	for i := 0; i < p.n; i++ {
+	for i = 0; i < p.n; i++ {
 		val = p.noise1(px)
 		sum += val / scale
 		scale *= p.alpha
@@ -257,11 +257,12 @@ func (p *Perlin) Noise2D(x, y float64) float64 {
 	var scale float64 = 1
 	var sum, val float64
 	var px [2]float64
+	var i int32
 
 	px[0] = x
 	px[1] = y
 
-	for i := 0; i < p.n; i++ {
+	for i = 0; i < p.n; i++ {
 		val = p.noise2(px)
 		sum += val / scale
 		scale *= p.alpha
@@ -276,6 +277,7 @@ func (p *Perlin) Noise3D(x, y, z float64) float64 {
 	var scale float64 = 1
 	var sum, val float64
 	var px [3]float64
+	var i int32
 
 	if z < 0.0000 {
 		return p.Noise2D(x, y)
@@ -285,7 +287,7 @@ func (p *Perlin) Noise3D(x, y, z float64) float64 {
 	px[1] = y
 	px[2] = z
 
-	for i := 0; i < p.n; i++ {
+	for i = 0; i < p.n; i++ {
 		val = p.noise3(px)
 		sum += val / scale
 		scale *= p.alpha

--- a/perlin.go
+++ b/perlin.go
@@ -1,5 +1,5 @@
 // Package perlin provides coherent noise function over 1, 2 or 3 dimensions
-// This code is go adaptagion based on C implementation that can be found here:
+// This code is go adaptation based on C implementation that can be found here:
 // http://git.gnome.org/browse/gegl/tree/operations/common/perlin/perlin.c
 // (original copyright Ken Perlin)
 package perlin
@@ -44,7 +44,7 @@ func NewPerlin(alpha, beta float64, n int32, seed int64) *Perlin {
 // number of iterations and source is source of pseudo-random int64 values
 func NewPerlinRandSource(alpha, beta float64, n int32, source rand.Source) *Perlin {
 	var p Perlin
-	var i, j, k int32
+	var i, j int32
 
 	p.alpha = alpha
 	p.beta = beta
@@ -69,15 +69,12 @@ func NewPerlinRandSource(alpha, beta float64, n int32, source rand.Source) *Perl
 	}
 
 	for ; i > 0; i-- {
-		k = p.p[i]
 		j = r.Int31() % B
-		p.p[i] = p.p[j]
-		p.p[j] = k
+		p.p[i], p.p[j] = p.p[j], p.p[i]
 	}
 
 	for i = 0; i < B+2; i++ {
-		p.p[B+i] = p.p[i]
-		p.g1[B+i] = p.g1[i]
+		p.p[B+i], p.g1[B+i] = p.p[i], p.g1[i]
 		for j = 0; j < 2; j++ {
 			p.g2[B+i][j] = p.g2[i][j]
 		}
@@ -91,15 +88,12 @@ func NewPerlinRandSource(alpha, beta float64, n int32, source rand.Source) *Perl
 
 func normalize2(v *[2]float64) {
 	s := math.Sqrt(v[0]*v[0] + v[1]*v[1])
-	v[0] = v[0] / s
-	v[1] = v[1] / s
+	v[0], v[1] = v[0]/s, v[1]/s
 }
 
 func normalize3(v *[3]float64) {
 	s := math.Sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2])
-	v[0] = v[0] / s
-	v[1] = v[1] / s
-	v[2] = v[2] / s
+	v[0], v[1], v[2] = v[0]/s, v[1]/s, v[2]/s
 }
 
 func at2(rx, ry float64, q [2]float64) float64 {
@@ -256,11 +250,8 @@ func (p *Perlin) Noise1D(x float64) float64 {
 func (p *Perlin) Noise2D(x, y float64) float64 {
 	var scale float64 = 1
 	var sum, val float64
-	var px [2]float64
 	var i int32
-
-	px[0] = x
-	px[1] = y
+	px := [2]float64{x, y}
 
 	for i = 0; i < p.n; i++ {
 		val = p.noise2(px)
@@ -276,16 +267,12 @@ func (p *Perlin) Noise2D(x, y float64) float64 {
 func (p *Perlin) Noise3D(x, y, z float64) float64 {
 	var scale float64 = 1
 	var sum, val float64
-	var px [3]float64
 	var i int32
+	px := [3]float64{x, y, z}
 
 	if z < 0.0000 {
 		return p.Noise2D(x, y)
 	}
-
-	px[0] = x
-	px[1] = y
-	px[2] = z
 
 	for i = 0; i < p.n; i++ {
 		val = p.noise3(px)


### PR DESCRIPTION
Uses `int32` internally instead of `int` which is platform dependant.